### PR TITLE
pod filter based on replication_type

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/plus/HeimdallPodFilter.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/plus/HeimdallPodFilter.java
@@ -1,0 +1,196 @@
+package com.salesforce.dva.argus.service.metric.transform.plus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.PatternSyntaxException;
+
+import com.salesforce.dva.argus.entity.Metric;
+import com.salesforce.dva.argus.service.metric.transform.Transform;
+import com.salesforce.dva.argus.system.SystemAssert;
+
+public class HeimdallPodFilter implements Transform {
+	
+	//DGoWAN or SRDF
+	private	float mode = (float) -1.0f;
+	private Float minusOne = -1.00f;
+	final private String typeName = "replication_type";
+	
+	//Map will save names of pod which are of 'mode' type
+	private Map<String, Integer> filteredMap = new HashMap<String, Integer>();
+	  List<Metric> filteredMetricsList;
+	
+	
+
+	@Override
+	public List<Metric> transform(List<Metric> metrics) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public List<Metric> transform(List<Metric> metrics, List<String> constants) {
+		
+		SystemAssert.requireArgument(constants.size()==1, "This transform needs constants - threshold");
+        Float podType = Float.parseFloat(constants.get(0));
+        SystemAssert.requireArgument( (Float.compare(podType, (float)1.0) == 0) || (Float.compare(podType, (float)0.0) == 0), "PodType Invalid, use 1.0 - DGoWAN and  0.0 - SRDF");
+        
+        setPodType(podType);
+        
+        /* 
+         * Scan through all the metrics and check replication flag 
+         * for each pod, add to filteredMap based on 'mode'
+         */
+        for(Metric metric: metrics){
+        	
+    		
+    		try {
+    			
+    			String scope = metric.getScope();
+        		String[] parts = scope.split("\\.");
+        		String pod = parts[3];
+        	
+	        	if(!checkReplicationFlag(metric.getMetric()) || filteredMap.containsKey(pod)){
+	        		continue;
+	        	}
+	        	
+	        	if(!checkPodType(metric.getDatapoints())){
+	        		continue;
+	        	}
+	        	else{
+	        			//put in our map
+	            		filteredMap.put(pod, new Integer(1));	
+	        	}
+        	
+			}catch(PatternSyntaxException e){
+				System.out.println("Invalid Regex Expression");
+	
+			}catch(Exception e){
+				System.out.println("Broken scope: " + metric.getScope());
+			}
+        }
+        
+        //Initialize the metrics list to be returned
+        filteredMetricsList = new ArrayList<Metric>();
+        
+        //select metrics to be returned
+        filterMetrics(metrics);
+        
+        //return only the metrics which are related to pods from filterMap
+		return filteredMetricsList;
+	}
+
+
+	/*
+	 * insert metrics related to pods in the filteredMap only in the filteredMetrics list
+	 */
+	private void filterMetrics(List<Metric> metrics) {
+		
+		for(Metric metric: metrics){
+			
+    		try {
+    			
+        		String scope = metric.getScope();
+        		String[] parts = scope.split("\\.");
+        		String pod = parts[3];
+        		String[] pieces = metric.getMetric().split("\\.");	
+        		
+        		if(filteredMap.containsKey(pod) && !typeName.equals(pieces[1])){
+        			this.filteredMetricsList.add(metric);
+        		}
+    			
+    		}catch(PatternSyntaxException e){
+    			System.out.println("Invalid Regex Expression");
+
+    		}catch(Exception e){
+    			System.out.println("Broken scope: " + metric.getScope());
+    		}
+			
+		}
+		
+		
+		
+	}
+
+	private boolean checkPodType(Map<Long, String> datapoints) {
+		
+		try{
+		
+	    	for(Map.Entry<Long, String> point : datapoints.entrySet()){
+	    		
+	    		Float value = Float.parseFloat(point.getValue());
+	    		
+	    		int	cmpVal = Float.compare(value, minusOne);
+	    		if(cmpVal == 0){
+	    			continue;
+	    		}
+	    		else {
+	    			
+	    			cmpVal = Float.compare(value, this.mode);
+	    			if(cmpVal == 0){
+	    				return true;
+	    			}
+	    			else{
+	    				return false;
+	    			}
+	    		}
+	    	}
+	    	
+		}
+		catch(NumberFormatException e){
+			System.out.println("string does not contain a parsable float");
+		}
+		catch(Exception e){
+			System.out.println(e.toString());
+		}
+		
+		//This return statement will execute if there are no datapoints to make a decision from.
+		return false;
+	}
+
+	@Override
+	public List<Metric> transform(List<Metric>... metrics) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public String getResultScopeName() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	private boolean checkReplicationFlag(String metricName) {
+		
+		try{
+		
+			String[] pieces = metricName.split("\\.");	
+			
+			if(typeName.equals(pieces[1])){
+			
+				return true;
+			}
+			else{
+				return false;
+			}
+			
+		}
+		catch(PatternSyntaxException e){
+			System.out.println("Invalid Regex Expression");
+			return	false;
+		}
+		catch(Exception e){
+			System.out.println("Broken metric name: "+ metricName);
+			return	false;
+		}
+		
+		
+	}	
+	
+	//Filter DGoWAN pods or SRDF pods
+	public void setPodType(Float podType){
+		this.mode = podType;
+	}
+
+}

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/plus/HeimdallPodFilterTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/plus/HeimdallPodFilterTest.java
@@ -1,0 +1,111 @@
+package com.salesforce.dva.argus.service.metric.transform.plus;
+
+import static org.hamcrest.MatcherAssert.assertThat; 
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith; 
+import org.mockito.Mock;
+import org.mockito.Mockito;  
+import org.mockito.runners.MockitoJUnitRunner; 
+
+/** import com.google.inject.Inject;  **/ 
+import com.salesforce.dva.argus.entity.Metric;
+import com.salesforce.dva.argus.service.metric.transform.Transform;
+import com.salesforce.dva.argus.service.metric.transform.plus.HeimdallPodFilter;
+
+public class HeimdallPodFilterTest {
+	
+	 private static final String TEST_SCOPE_1 = "db.CHI.SP4.na27";
+	 private static final String TEST_METRIC_1 = "NA27DB1CHI.replication_type";
+	 private static final String TEST_SCOPE_2 = "db.WAS.SP4.na30";
+	 private static final String TEST_METRIC_2 = "NA30DB1WAS.replication_type";	
+	 private static final String TEST_SCOPE_3 = "db.WAS.SP4.na44";
+	 private static final String TEST_METRIC_3 = "NA44DB1WAS.replication_type";	
+	 
+	 private static final String TEST_SCOPE_4 = "db.CHI.SP4.na27";
+	 private static final String TEST_METRIC_4 = "NA27DB1CHI.remote_dg_transport_lag";
+	 private static final String TEST_SCOPE_5 = "db.WAS.SP4.na30";
+	 private static final String TEST_METRIC_5 = "NA30DB1WAS.local_dataguard_lag";	
+	 private static final String TEST_SCOPE_6 = "db.WAS.SP4.na44";
+	 private static final String TEST_METRIC_6 = "NA44DB1WAS.remote_dg_transport_lag";	
+	 
+	 
+	 @Test
+	 public void podFilterTest(){
+		 
+		 Transform transform = new HeimdallPodFilter();	
+		 
+			Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+	        datapoints_1.put(1473389110000L, "1.0");
+	        datapoints_1.put(1473389162000L, "1.0");
+	        datapoints_1.put(1473389221000L, "1.0");
+	        datapoints_1.put(1473389282000L, "1.0");
+	        datapoints_1.put(1473389341000L, "1.0");
+	        datapoints_1.put(1473389402001L, "1.0");
+	        datapoints_1.put(1473389221002L, "1.0");
+	        datapoints_1.put(1473389282002L, "-1.0");
+	        datapoints_1.put(1473389341002L, "1.0");
+	        datapoints_1.put(1473389402003L, "1.0"); 
+	       
+	        
+	        Metric metric_1 = new Metric(TEST_SCOPE_1, TEST_METRIC_1);
+	        metric_1.setDatapoints(datapoints_1);
+	        
+			Map<Long, String> datapoints_2 = new HashMap<Long, String>();
+	        datapoints_2.put(1473390730000L, "-1.0");
+	        datapoints_2.put(1473390782000L, "0.0");
+	        datapoints_2.put(1473390842002L, "0.0");
+	        datapoints_2.put(1473390902004L, "0.0");
+	        datapoints_2.put(1473390962003L, "0.0");
+	        datapoints_2.put(1473391022003L, "0.0");
+	        datapoints_2.put(1473390601002L, "0.0");
+	        datapoints_2.put(1473390662001L, "-1.0");
+	        datapoints_2.put(1473390730007L, "0.0");
+	        datapoints_2.put(1473390782002L, "0.0"); 
+	       
+	        
+	        Metric metric_2 = new Metric(TEST_SCOPE_2, TEST_METRIC_2);
+	        metric_2.setDatapoints(datapoints_2);
+
+	        Map<Long, String> datapoints_3 = new HashMap<Long, String>();
+	        Metric metric_3 = new Metric(TEST_SCOPE_3, TEST_METRIC_3);
+	        metric_3.setDatapoints(datapoints_3);
+	        //empty data-points
+	        
+	        
+	        Metric metric_4 = new Metric(TEST_SCOPE_4, TEST_METRIC_4);
+	        Metric metric_5 = new Metric(TEST_SCOPE_5, TEST_METRIC_5);
+	        Metric metric_6 = new Metric(TEST_SCOPE_6, TEST_METRIC_6);
+	        List<Metric> metrics = new ArrayList<Metric>();
+	        metrics.add(metric_1);
+	        metrics.add(metric_2);
+	        metrics.add(metric_3);
+	        metrics.add(metric_4);
+	        metrics.add(metric_5);
+	        metrics.add(metric_6);
+	        
+	        List<String> constants = new ArrayList<String>();
+
+	        //Looking for DGoWAN pods
+	        constants.add("1.00");
+	        
+	        //System.out.println("Threshold: 120sec");
+	        List<Metric> result = transform.transform(metrics,constants);
+	        //System.out.print(result.toString()); 
+	        
+	        // only na27 related metrics should be seen after using filter(na27 is DGoWAN)
+	        assertEquals(result.size(), 1);
+	        assertEquals(metric_4.getMetric(), result.get(0).getMetric());
+	        assertEquals(metric_4.getScope(), result.get(0).getScope());
+	        
+	        
+	 }
+
+}


### PR DESCRIPTION
This transform filters pods based on replication_type. 

A constant has to be supplied to the transform(1.0 - DGoWAN, 0.0 - SRDF) based on which the filtering will take place. It returns a list of metrics belonging to the pods which pass the filter.